### PR TITLE
Fix code scanning alert no. 5: Creating biased random numbers from a cryptographically secure source

### DIFF
--- a/src/pages/Password.tsx
+++ b/src/pages/Password.tsx
@@ -145,7 +145,14 @@ const generatePassword = () => {
 const getPassword = (
 	length = 20,
 	characters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz~!@-#$+*",
-) =>
-	Array.from(crypto.getRandomValues(new Uint32Array(length)))
-		.map((x) => characters[x % characters.length])
-		.join("");
+) => {
+	const password = [];
+	const maxMultiple = Math.floor(256 / characters.length) * characters.length;
+	while (password.length < length) {
+		const byte = crypto.getRandomValues(new Uint8Array(1))[0];
+		if (byte < maxMultiple) {
+			password.push(characters[byte % characters.length]);
+		}
+	}
+	return password.join("");
+};


### PR DESCRIPTION
Fixes [https://github.com/Lukas-Nielsen/tools/security/code-scanning/5](https://github.com/Lukas-Nielsen/tools/security/code-scanning/5)

To fix the problem, we need to avoid using the modulo operator directly on the cryptographically secure random number. Instead, we can use a method that ensures uniform distribution by discarding values that would introduce bias. This can be achieved by generating random numbers within a range that is a multiple of the length of the characters array and discarding any values that fall outside this range.

We will modify the `getPassword` function to implement this approach. Specifically, we will:
1. Generate random bytes and discard any values that are greater than or equal to the largest multiple of the characters array length that is less than 256.
2. Use the remaining values to index into the characters array.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
